### PR TITLE
Removed requirejs, using standard browser ESModules

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,19 +7,12 @@
 
    <link rel="stylesheet" href="./styles.css">
 
-   <script src="https://requirejs.org/docs/release/2.3.6/minified/require.js"></script>
-
    <!-- The JavaScript generated from all the TypeScript files -->
-   <script src="./dist/dist.js"></script>
+   <script src="./dist/index.js" type="module"></script>
 
    <title>Screen Savior</title>
 </head>
 <body>
    <canvas id="canvas"></canvas>
-
-   <script>
-      // 'index' - name of the TypeScript files which contains the entrypoint of the application.
-      require(['index']);
-   </script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,8 +1,7 @@
 {
    "scripts": {
       "start": "http-server",
-      "build": "tsc",
-      "build:watch": "tsc --watch"
+      "build": "tsc"
    },
    "dependencies": {
       "typescript": "^4.5.5"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
    "scripts": {
-      "start": "serve",
-      "build": "tsc --watch"
+      "start": "http-server",
+      "build": "tsc",
+      "build:watch": "tsc --watch"
    },
    "dependencies": {
       "typescript": "^4.5.5"
@@ -10,6 +11,6 @@
       "@typescript-eslint/eslint-plugin": "^5.12.0",
       "@typescript-eslint/parser": "^5.12.0",
       "eslint": "^8.9.0",
-      "serve": "^13.0.2"
+      "http-server": "^14.1.0"
    }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
    "scripts": {
-      "start": "tsc"
+      "start": "serve",
+      "build": "tsc --watch"
    },
    "dependencies": {
       "typescript": "^4.5.5"
@@ -8,6 +9,7 @@
    "devDependencies": {
       "@typescript-eslint/eslint-plugin": "^5.12.0",
       "@typescript-eslint/parser": "^5.12.0",
-      "eslint": "^8.9.0"
+      "eslint": "^8.9.0",
+      "serve": "^13.0.2"
    }
 }

--- a/src/RainColumn.ts
+++ b/src/RainColumn.ts
@@ -1,8 +1,8 @@
-import { SETTINGS } from './_settings'
-import { COLORS } from './colors'
-import { RAINDROP_STATES } from './RaindropStates'
-import { getRandomCharacter, getRandomNumber } from './helpers'
-import { Raindrop } from './Raindrop'
+import { SETTINGS } from './_settings.js'
+import { COLORS } from './colors.js'
+import { RAINDROP_STATES } from './RaindropStates.js'
+import { getRandomCharacter, getRandomNumber } from './helpers.js'
+import { Raindrop } from './Raindrop.js'
 
 /** I repesent a single vertical column in the matrix rain. */
 export class RainColumn {

--- a/src/Raindrop.ts
+++ b/src/Raindrop.ts
@@ -1,4 +1,4 @@
-import { RAINDROP_STATES } from './RaindropStates'
+import { RAINDROP_STATES } from './RaindropStates.js'
 
 /** I represent a single character in a rain column. */
 export class Raindrop {

--- a/src/colors.ts
+++ b/src/colors.ts
@@ -1,4 +1,4 @@
-import { SETTINGS } from './_settings'
+import { SETTINGS } from './_settings.js'
 
 /**
  * Calculate a hex color in specific stop between two colors.

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,4 +1,4 @@
-import { CHARACTERS } from './characters'
+import { CHARACTERS } from './characters.js'
 
 /**
  * Generate a random number between zero and provided max value.

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,9 +4,9 @@
  * If renaming this file - also rename it in index.html!
  */
 
-import { SETTINGS } from './_settings'
-import { RainColumn } from './RainColumn'
-import { getRandomNumber } from './helpers'
+import { SETTINGS } from './_settings.js'
+import { RainColumn } from './RainColumn.js'
+import { getRandomNumber } from './helpers.js'
 
 function startApplication() {
    const canvas = document.getElementById('canvas') as HTMLCanvasElement

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "watch": true,
     // "incremental": true,                         /* Enable incremental compilation */
     "target": "ES2015",                             /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
-    "module": "amd",                                /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
+    "module": "ES2015",                                /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
     // "lib": [],                                   /* Specify library files to be included in the compilation. */
     "allowJs": true,                                /* Allow javascript files to be compiled. */
     "checkJs": true,                                /* Report errors in .js files. */
@@ -14,8 +14,8 @@
     "declaration": true,                            /* Generates corresponding '.d.ts' file. */
     "declarationMap": true,                         /* Generates a sourcemap for each corresponding '.d.ts' file. */
     "sourceMap": true,                              /* Generates corresponding '.map' file. */
-    "outFile": "dist/dist.js",                      /* Concatenate and emit output to single file. */
-    // "outDir": "dist",                            /* Redirect output structure to the directory. */
+    // "outFile": "dist/dist.js",                      /* Concatenate and emit output to single file. */
+    "outDir": "dist",                            /* Redirect output structure to the directory. */
     "rootDir": "src",                               /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "composite": true,                           /* Enable project compilation */
     // "tsBuildInfoFile": "./",                     /* Specify file to store incremental compilation information */


### PR DESCRIPTION
Using JS standard import
https://caniuse.com/mdn-javascript_statements_import

Unfortunately:
* typescript doesn't know how to modify file endings for imports. Added *.js to all imports
* ESModule has browser limitations, due to security reasons, they are not allowing to access local system files from within js, Js modules included. Need simple server to host static files

Added:
* script "build" to build once
* script "start" to start http-server
* new dev dependency "http-server", simply hosts a static file server on localhost
* Cleaner dist, without requirejs dependency, more vanilla js